### PR TITLE
Add VPC ID to outputs and is_default variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_project"></a> [project](#input\_project) | Project configuration | `map(string)` | <pre>{<br>  "description": "My project",<br>  "environment": "development",<br>  "is_default": "false",<br>  "name": "My_Project",<br>  "purpose": "Personal"<br>}</pre> | no |
+| <a name="input_project"></a> [project](#input\_project) | Project configuration | <pre>object({<br>    name        = string<br>    description = string<br>    purpose     = string<br>    environment = string<br>    is_default  = bool<br>  })</pre> | <pre>{<br>  "description": "My project",<br>  "environment": "development",<br>  "is_default": "false",<br>  "name": "My_Project",<br>  "purpose": "Personal"<br>}</pre> | no |
 | <a name="input_vpc_description"></a> [vpc\_description](#input\_vpc\_description) | Description of the VPC | `string` | `"My VPC is the raddest"` | no |
 | <a name="input_vpc_name"></a> [vpc\_name](#input\_vpc\_name) | Name of the VPC to create | `string` | `"my-vpc"` | no |
 | <a name="input_vpc_region"></a> [vpc\_region](#input\_vpc\_region) | Slug of the digitalocean region | `string` | `"ams3"` | no |

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_project"></a> [project](#input\_project) | Project configuration | `map(string)` | <pre>{<br>  "description": "My project",<br>  "environment": "development",<br>  "name": "My_Project",<br>  "purpose": "Personal"<br>}</pre> | no |
+| <a name="input_project"></a> [project](#input\_project) | Project configuration | `map(string)` | <pre>{<br>  "description": "My project",<br>  "environment": "development",<br>  "is_default": "false",<br>  "name": "My_Project",<br>  "purpose": "Personal"<br>}</pre> | no |
 | <a name="input_vpc_description"></a> [vpc\_description](#input\_vpc\_description) | Description of the VPC | `string` | `"My VPC is the raddest"` | no |
 | <a name="input_vpc_name"></a> [vpc\_name](#input\_vpc\_name) | Name of the VPC to create | `string` | `"my-vpc"` | no |
 | <a name="input_vpc_region"></a> [vpc\_region](#input\_vpc\_region) | Slug of the digitalocean region | `string` | `"ams3"` | no |
@@ -48,4 +48,5 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_vpc_cidr"></a> [vpc\_cidr](#output\_vpc\_cidr) | terraform-digitalocean-vpc outputs |
+| <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc\_id) | n/a |
 <!-- END_TF_DOCS -->

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_project"></a> [project](#input\_project) | Project configuration | <pre>object({<br>    name        = string<br>    description = string<br>    purpose     = string<br>    environment = string<br>    is_default  = bool<br>  })</pre> | <pre>{<br>  "description": "My project",<br>  "environment": "development",<br>  "is_default": "false",<br>  "name": "My_Project",<br>  "purpose": "Personal"<br>}</pre> | no |
+| <a name="input_project"></a> [project](#input\_project) | Project configuration | <pre>object({<br>    name        = string<br>    description = string<br>    purpose     = string<br>    environment = string<br>    is_default  = bool<br>  })</pre> | <pre>{<br>  "description": "My project",<br>  "environment": "development",<br>  "is_default": false,<br>  "name": "My_Project",<br>  "purpose": "Personal"<br>}</pre> | no |
 | <a name="input_vpc_description"></a> [vpc\_description](#input\_vpc\_description) | Description of the VPC | `string` | `"My VPC is the raddest"` | no |
 | <a name="input_vpc_name"></a> [vpc\_name](#input\_vpc\_name) | Name of the VPC to create | `string` | `"my-vpc"` | no |
 | <a name="input_vpc_region"></a> [vpc\_region](#input\_vpc\_region) | Slug of the digitalocean region | `string` | `"ams3"` | no |

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -39,6 +39,7 @@ module "example" {
     description = "Test project for CI purposes"
     purpose     = "Continuous integration"
     environment = "development"
+    is_default  = true
   }
   vpc_name        = var.vpc_name
   vpc_description = "Test VPC for CI"

--- a/main.tf
+++ b/main.tf
@@ -9,6 +9,7 @@ resource "digitalocean_project" "p" {
   description = var.project.description
   purpose     = var.project.purpose
   environment = var.project.environment
+  is_default  = var.project.is_default
 }
 
 resource "digitalocean_vpc" "vpc" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,3 +2,7 @@
 output "vpc_cidr" {
   value = digitalocean_vpc.vpc.ip_range
 }
+
+output "vpc_id" {
+  value = digitalocean_vpc.vpc.id
+}

--- a/variables.tf
+++ b/variables.tf
@@ -18,13 +18,19 @@ variable "vpc_description" {
 }
 
 variable "project" {
-  type        = map(string)
+  type        = object({
+    name        = string
+    description = string
+    purpose     = string
+    environment = string
+    is_default  = bool
+  })
   description = "Project configuration"
   default = {
     name        = "My_Project"
     description = "My project"
     purpose     = "Personal"
     environment = "development"
-    is_default  = "false"
+    is_default  = false
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -25,5 +25,6 @@ variable "project" {
     description = "My project"
     purpose     = "Personal"
     environment = "development"
+    is_default  = "false"
   }
 }


### PR DESCRIPTION
This commit adds VPC ID to outputs of terraform. ID is required to pass as an input to kubernetes module. `is_default` variable allows to create default projects.